### PR TITLE
Add more information about what happend when executing a check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 
 [workspace]
+resolver = "2"
 members = [
     "bin",
     "lib",

--- a/bin/src/checks.rs
+++ b/bin/src/checks.rs
@@ -1,43 +1,36 @@
 use async_trait::async_trait;
-use bridgehead_monitoring_lib::Check;
+use bridgehead_monitoring_lib::{Check, CheckResult};
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{CLIENT, CONFIG};
 
 #[async_trait]
 pub trait CheckExecutor {
-    async fn execute(&self) -> String;
+    async fn execute(&self) -> Result<CheckResult, CheckResult>;
 }
 
 #[async_trait]
 impl CheckExecutor for Check {
-    async fn execute(&self) -> String {
+    async fn execute(&self) -> Result<CheckResult, CheckResult> {
         match self {
             Check::BlazeHealth => {
-                match CLIENT.get(format!("{}health", CONFIG.blaze_url)).send().await {
-                    Ok(res) => {
-                        res.status().to_string()
-                    },
-                    Err(e) => e.to_string()
+                let res = CLIENT.get(format!("{}health", CONFIG.blaze_url)).send().await?;
+                if res.status() == StatusCode::OK {
+                    Ok(CheckResult::Ok(res.status().to_string()))
+                } else {
+                    Err(CheckResult::Err(format!("Unhealthy: {}", res.status())))
                 }
             },
             Check::BlazeResources => {
-                match CLIENT.get(format!("{}fhir", CONFIG.blaze_url)).send().await {
-                    Ok(res) => {
-                        let json = &res.json::<Value>().await.unwrap_or(Value::Null)["total"];
-                        serde_json::to_string(json).unwrap_or_else(|e| e.to_string())
-                    },
-                    Err(e) => e.to_string()
-                }
+                let res = CLIENT.get(format!("{}fhir", CONFIG.blaze_url)).send().await?;
+                let json = &res.json::<Value>().await?["total"];
+                Ok(CheckResult::Ok(serde_json::to_string(json)?))
             },
             Check::BlazeVersion => {
-                match CLIENT.get(format!("{}fhir/metadata", CONFIG.blaze_url)).send().await {
-                    Ok(res) => {
-                        let json = &res.json::<Value>().await.unwrap_or(Value::Null)["software"]["version"];
-                        serde_json::to_string(json).unwrap_or_else(|e| e.to_string())
-                    },
-                    Err(e) => e.to_string()
-                }
+                let res = CLIENT.get(format!("{}fhir/metadata", CONFIG.blaze_url)).send().await?;
+                let json = &res.json::<Value>().await?["software"]["version"];
+                Ok(CheckResult::Ok(serde_json::to_string(json)?))
             }
         }
     }

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -5,7 +5,7 @@ use checks::CheckExecutor;
 use clap::Parser;
 use config::Config;
 use bridgehead_monitoring_lib::{Check, CheckResult};
-use futures::{future::join_all, SinkExt, FutureExt};
+use futures::{future::join_all, FutureExt};
 use once_cell::sync::Lazy;
 use reqwest::{Client, StatusCode, header::{HeaderMap, AUTHORIZATION, HeaderValue, ACCEPT}};
 use serde_json::Value;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, error::Error};
 
 use serde::{Serialize, Deserialize};
 
@@ -18,5 +18,18 @@ impl fmt::Display for Check {
             Check::BlazeResources => "Blaze Resources",
         };
         f.write_str(name)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum CheckResult {
+    Ok(String),
+    Err(String),
+    Unexpected(String)
+}
+
+impl<E: Error> From<E> for CheckResult {
+    fn from(value: E) -> Self {
+        Self::Err(value.to_string())
     }
 }


### PR DESCRIPTION
- Add a `CheckResult` type to give beamctl more info
- Update workspace resolver to v2

While `Result<CheckResult, CheckResult>` looks silly I think it simplifies the code enough to make it worth while imo.